### PR TITLE
BACKLOG-22443 : replace blueprint EDP check by annotated class to fix…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -227,6 +227,16 @@
                     <outputName>java-bom.cdx</outputName>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <_dsannotations>*</_dsannotations>
+                    </instructions>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core/src/main/java/org/jahia/modules/external/users/osgi/UsersGroupsProviderComponent.java
+++ b/core/src/main/java/org/jahia/modules/external/users/osgi/UsersGroupsProviderComponent.java
@@ -1,0 +1,76 @@
+/*
+ * ==========================================================================================
+ * =                   JAHIA'S DUAL LICENSING - IMPORTANT INFORMATION                       =
+ * ==========================================================================================
+ *
+ *                                 http://www.jahia.com
+ *
+ *     Copyright (C) 2002-2024 Jahia Solutions Group SA. All rights reserved.
+ *
+ *     THIS FILE IS AVAILABLE UNDER TWO DIFFERENT LICENSES:
+ *     1/GPL OR 2/JSEL
+ *
+ *     1/ GPL
+ *     ==================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE GPL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *     2/ JSEL - Commercial and Supported Versions of the program
+ *     ===================================================================================
+ *
+ *     IF YOU DECIDE TO CHOOSE THE JSEL LICENSE, YOU MUST COMPLY WITH THE FOLLOWING TERMS:
+ *
+ *     Alternatively, commercial and supported versions of the program - also known as
+ *     Enterprise Distributions - must be used in accordance with the terms and conditions
+ *     contained in a separate written agreement between you and Jahia Solutions Group SA.
+ *
+ *     If you are unsure which license is appropriate for your use,
+ *     please contact the sales department at sales@jahia.com.
+ */
+package org.jahia.modules.external.users.osgi;
+
+import org.jahia.modules.external.ExternalProviderInitializerService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This OSGi service to ensure external provider spring context available before starting this module
+ */
+@Component(immediate = true, service = UsersGroupsProviderComponent.class)
+public class UsersGroupsProviderComponent {
+    private static final Logger logger = LoggerFactory.getLogger(UsersGroupsProviderComponent.class);
+
+    /**
+     * Not used reference to ensure the reference is available before starting this module.
+     */
+
+    private ExternalProviderInitializerService externalProviderInitializerService;
+
+    @Reference
+    public void setExternalProviderInitializerService(ExternalProviderInitializerService externalProviderInitializerService) {
+        this.externalProviderInitializerService = externalProviderInitializerService;
+    }
+
+    @Activate
+    private void activate() {
+        logger.info("ExternalProviderInitializerService {} Available", externalProviderInitializerService.toString());
+    }
+
+}

--- a/core/src/main/resources/META-INF/spring/external-provider-users-groups.xml
+++ b/core/src/main/resources/META-INF/spring/external-provider-users-groups.xml
@@ -5,9 +5,6 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
                         http://www.eclipse.org/gemini/blueprint/schema/blueprint http://www.eclipse.org/gemini/blueprint/schema/blueprint/gemini-blueprint.xsd">
 
-  <!-- This ref is not used, but necessary to be sure that spring context from external-provider is started before the current context -->
-  <osgi:reference id="ExternalProviderInitializerService" interface="org.jahia.modules.external.ExternalProviderInitializerService"/>
-
   <bean id="messageSource" class="org.jahia.utils.i18n.ModuleMessageSource"/>
 
   <bean id="ExternalUserGroupServiceImpl" class="org.jahia.modules.external.users.impl.ExternalUserGroupServiceImpl">

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
       <tag>HEAD</tag>
   </scm>
 
+    <properties>
+        <jahia.plugin.version>6.9</jahia.plugin.version>
+    </properties>
+
     <repositories>
         <repository>
             <id>jahia-public</id>


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-22443
When the module was refreshed externally, spring context refresh was not able to access EDP beans. Moving the service declaration to an OSGi annotation fixes the issue. 