### PR TITLE
BACKLOG-22971: Replace spring prototype bean init with OSGi factory service

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -12,18 +12,17 @@ jobs:
     name: Update module signature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
 
   static-analysis:
     name: Static Analysis (linting, vulns)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
           node_version: 18
@@ -34,12 +33,12 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/build@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -51,7 +50,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
           primary_release_branch: master

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -15,24 +15,23 @@ jobs:
     name: Update module signature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
 
   build:
     name: Build Module
     needs: update-signature
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/build@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
@@ -58,12 +57,12 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/publish@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -15,7 +15,7 @@ jobs:
     # downloading the entire world when building.
     # More on https://github.com/Jahia/cimg-mvn-cache
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Providing the SSH PRIVATE of a user part of an admin group
       # is necessary to bypass PR checks
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
 
@@ -48,7 +48,6 @@ jobs:
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
           force_signature: true
 
       - uses: jahia/jahia-modules-action/release-publication@v2

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -19,12 +19,12 @@ jobs:
       matrix:
          supported_branches: ["${{ github.event.repository.default_branch }}"]
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.supported_branches }}
       - uses: jahia/jahia-modules-action/build@v2

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,7 +74,7 @@
         <require-capability>
             osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"
         </require-capability>
-        <jahia-module-signature>MCwCFGuK2TvoTlXEEbN45uJ+fbX/7xFfAhQDD8iF+lK2o1Wzxg40HgRw2YqYfg==</jahia-module-signature>
+        <jahia-module-signature>MCwCFDv7HuZe6m7HUfhqq22JzhdHb4l0AhQYasch3/QPMVhKAjFjsDENcT1XmA==</jahia-module-signature>
         <yarn.arguments>build:production</yarn.arguments>
         <sonar.sources>src/javascript</sonar.sources>
     </properties>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>external-provider</artifactId>
-            <version>4.0.0</version>
+            <version>4.7.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -228,6 +228,14 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.9</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>biz.aQute.bndlib</artifactId>
+                        <version>6.4.0</version>
+                    </dependency>
+                </dependencies>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/core/src/main/java/org/jahia/modules/external/users/impl/ExternalUserGroupServiceImpl.java
+++ b/core/src/main/java/org/jahia/modules/external/users/impl/ExternalUserGroupServiceImpl.java
@@ -44,14 +44,13 @@
 package org.jahia.modules.external.users.impl;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.gemini.blueprint.context.BundleContextAware;
 import org.jahia.exceptions.JahiaInitializationException;
 import org.jahia.modules.external.ExternalContentStoreProvider;
+import org.jahia.modules.external.ExternalContentStoreProviderFactory;
 import org.jahia.modules.external.users.ExternalUserGroupService;
 import org.jahia.modules.external.users.UserGroupProvider;
 import org.jahia.modules.external.users.UserGroupProviderConfiguration;
 import org.jahia.modules.external.users.UserGroupProviderRegistration;
-import org.jahia.services.SpringContextSingleton;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -61,14 +60,12 @@ import org.jahia.services.content.decorator.JCRMountPointNode;
 import org.jahia.services.usermanager.JahiaGroupManagerService;
 import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.jahia.settings.SettingsBean;
-import org.osgi.framework.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
@@ -85,6 +82,8 @@ public class ExternalUserGroupServiceImpl implements ExternalUserGroupService {
 
     private JahiaUserManagerService jahiaUserManagerService;
     private JahiaGroupManagerService jahiaGroupManagerService;
+
+    private ExternalContentStoreProviderFactory externalContentStoreProviderFactory;
 
     private String readOnlyUserProperties;
 
@@ -114,7 +113,7 @@ public class ExternalUserGroupServiceImpl implements ExternalUserGroupService {
                 UserDataSource userDataSource = new UserDataSource();
                 userDataSource.setJahiaUserManagerService(jahiaUserManagerService);
                 userDataSource.setUserGroupProvider(userGroupProvider);
-                ExternalContentStoreProvider userProvider = (ExternalContentStoreProvider) SpringContextSingleton.getBeanInModulesContext("ExternalStoreProviderPrototype");
+                ExternalContentStoreProvider userProvider = externalContentStoreProviderFactory.newProvider();
                 userProvider.setKey(userProviderKey);
                 String sitePath = "/sites/" + siteKey + "/";
                 userProvider.setMountPoint((siteKey == null ? "/" : sitePath) + USERS_FOLDER_NAME + "/" + PROVIDERS_MOUNT_CONTAINER + "/" + providerKey);
@@ -145,7 +144,7 @@ public class ExternalUserGroupServiceImpl implements ExternalUserGroupService {
                     groupDataSource.setJahiaGroupManagerService(jahiaGroupManagerService);
                     groupDataSource.setUserDataSource(userDataSource);
                     groupDataSource.setUserGroupProvider(userGroupProvider);
-                    groupProvider = (ExternalContentStoreProvider) SpringContextSingleton.getBeanInModulesContext("ExternalStoreProviderPrototype");
+                    groupProvider = externalContentStoreProviderFactory.newProvider();
                     groupProvider.setKey(groupProviderKey);
                     groupProvider.setMountPoint((siteKey == null ? "/" : sitePath)+ GROUPS_FOLDER_NAME + "/" + PROVIDERS_MOUNT_CONTAINER + "/" + providerKey);
                     groupProvider.setDataSource(groupDataSource);
@@ -290,6 +289,10 @@ public class ExternalUserGroupServiceImpl implements ExternalUserGroupService {
 
     public void setJahiaGroupManagerService(JahiaGroupManagerService jahiaGroupManagerService) {
         this.jahiaGroupManagerService = jahiaGroupManagerService;
+    }
+
+    public void setExternalContentStoreProviderFactory(ExternalContentStoreProviderFactory externalContentStoreProviderFactory) {
+        this.externalContentStoreProviderFactory = externalContentStoreProviderFactory;
     }
 
 }

--- a/core/src/main/resources/META-INF/spring/external-provider-users-groups.xml
+++ b/core/src/main/resources/META-INF/spring/external-provider-users-groups.xml
@@ -7,12 +7,14 @@
 
   <bean id="messageSource" class="org.jahia.utils.i18n.ModuleMessageSource"/>
 
+  <osgi:reference id="ExternalContentStoreProviderFactory" interface="org.jahia.modules.external.ExternalContentStoreProviderFactory"/>
   <bean id="ExternalUserGroupServiceImpl" class="org.jahia.modules.external.users.impl.ExternalUserGroupServiceImpl">
     <property name="userGroupProviderConfigurations" >
       <osgi:list availability="optional" interface="org.jahia.modules.external.users.UserGroupProviderConfiguration"/>
     </property>
     <property name="jahiaUserManagerService" ref="JahiaUserManagerService"/>
     <property name="jahiaGroupManagerService" ref="JahiaGroupManagerService"/>
+    <property name="externalContentStoreProviderFactory" ref="ExternalContentStoreProviderFactory"/>
     <property name="readOnlyUserProperties" value="${external.users.properties.readonly:j:firstName,j:lastName,j:organization,j:email}"/>
   </bean>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.0.0</version>
+        <version>8.2.0.4</version>
         <relativePath />
     </parent>
     <version>2.5.0-SNAPSHOT</version>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-22971

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Get rid of instantiating `ExternalContentStoreProvider` prototype bean using Spring which is prone to cause issues during startup and use new OSGi service `ExternalContentStoreProviderFactory` to provide instantiation of the prototype bean

Bumped jahia parent to 8.2 since this requires external-provider/4.7, and 4.7 requires 8.2 jahia parent.