### PR TITLE
fix: JSP injection in create/edit forms

### DIFF
--- a/.chachalog/jh3aJtN2.md
+++ b/.chachalog/jh3aJtN2.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+external-provider-users-groups: patch
+---
+
+Resolve the user/group provider create and edit forms' included JSP from the provider registry instead of the request.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,6 +92,20 @@
             <version>${gemini.blueprint.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/core/src/main/java/org/jahia/modules/external/users/admin/UserGroupProviderAdminFlow.java
+++ b/core/src/main/java/org/jahia/modules/external/users/admin/UserGroupProviderAdminFlow.java
@@ -183,7 +183,6 @@ public class UserGroupProviderAdminFlow implements Serializable {
             UserGroupProviderConfiguration configuration = configurations.get(userGroupProviderClass);
             if (configuration != null) {
                 providerInfo.setEditSupported(configuration.isEditSupported());
-                providerInfo.setEditJSP(configuration.getEditJSP());
                 providerInfo.setDeleteSupported(configuration.isDeleteSupported());
             }
             String siteKey = entry.getValue().getSiteKey();
@@ -200,6 +199,38 @@ public class UserGroupProviderAdminFlow implements Serializable {
             infos.add(providerInfo);
         }
         return infos;
+    }
+
+    /**
+     * Returns the JSP to include in the creation form of the given provider class.
+     * <p>
+     * The path is read back from the provider registry rather than taken from the request, so the form can only ever
+     * include a JSP that a registered provider declares for this purpose.
+     *
+     * @param providerClass
+     *            the provider class name submitted with the form
+     * @return the registered creation JSP, or <code>null</code> if the class is not registered or does not support
+     *         creation
+     */
+    public String resolveCreateJSP(String providerClass) {
+        UserGroupProviderConfiguration configuration = getConfiguration(providerClass);
+        return configuration != null && configuration.isCreateSupported() ? configuration.getCreateJSP() : null;
+    }
+
+    /**
+     * Returns the JSP to include in the edition form of the given provider class.
+     * <p>
+     * The path is read back from the provider registry rather than taken from the request, so the form can only ever
+     * include a JSP that a registered provider declares for this purpose.
+     *
+     * @param providerClass
+     *            the provider class name submitted with the form
+     * @return the registered edition JSP, or <code>null</code> if the class is not registered or does not support
+     *         edition
+     */
+    public String resolveEditJSP(String providerClass) {
+        UserGroupProviderConfiguration configuration = getConfiguration(providerClass);
+        return configuration != null && configuration.isEditSupported() ? configuration.getEditJSP() : null;
     }
 
     /**
@@ -262,6 +293,17 @@ public class UserGroupProviderAdminFlow implements Serializable {
             groupProvider.stop();
         }
         addNoteForCluster(messages);
+    }
+
+    private UserGroupProviderConfiguration getConfiguration(String providerClass) {
+        if (providerClass == null) {
+            return null;
+        }
+        UserGroupProviderConfiguration configuration = externalUserGroupService.getProviderConfigurations().get(providerClass);
+        if (configuration == null) {
+            logger.warn("No user/group provider is registered for class {}", providerClass);
+        }
+        return configuration;
     }
 
     private void wait(String providerKey, boolean shouldBeAvailable, MessageContext messages) {

--- a/core/src/main/java/org/jahia/modules/external/users/admin/UserGroupProviderInfo.java
+++ b/core/src/main/java/org/jahia/modules/external/users/admin/UserGroupProviderInfo.java
@@ -53,9 +53,7 @@ public class UserGroupProviderInfo implements Serializable {
     private static final long serialVersionUID = 8377758659660801865L;
 
     private boolean deleteSupported;
-    
-    private String editJSP;
-    
+
     private boolean editSupported;
     
     private boolean groupSupported;
@@ -69,10 +67,6 @@ public class UserGroupProviderInfo implements Serializable {
     private String siteKey;
 
     private boolean targetAvailable = true;
-
-    public String getEditJSP() {
-        return editJSP;
-    }
 
     public String getKey() {
         return key;
@@ -108,10 +102,6 @@ public class UserGroupProviderInfo implements Serializable {
 
     public void setDeleteSupported(boolean deleteSupported) {
         this.deleteSupported = deleteSupported;
-    }
-
-    public void setEditJSP(String editJSP) {
-        this.editJSP = editJSP;
     }
 
     public void setEditSupported(boolean editSupported) {

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/createProviderForm.jsp
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/createProviderForm.jsp
@@ -24,14 +24,20 @@
 </fmt:message></h2>
 
 <c:if test="${not empty error}">
-    <div class="alert alert-error">${error}</div>
+    <div class="alert alert-error">${fn:escapeXml(error)}</div>
 </c:if>
 
 <form style="margin: 0;" action="${flowExecutionUrl}" method="post" onsubmit="workInProgress('${i18nWaiting}')">
     <input type="hidden" name="providerClass" value="${providerClass}"/>
-    <input type="hidden" name="createJSP" value="${createJSP}"/>
 
-    <jsp:include page="${createJSP}"/>
+    <c:choose>
+        <c:when test="${not empty createJSP}">
+            <jsp:include page="${createJSP}"/>
+        </c:when>
+        <c:otherwise>
+            <div class="alert alert-error"><fmt:message key="label.userGroupProvider.unknownProvider"/></div>
+        </c:otherwise>
+    </c:choose>
 
     <div>
         <button class="btn btn-primary" type="submit" name="_eventId_create">

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/deleteProviderForm.jsp
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/deleteProviderForm.jsp
@@ -24,7 +24,7 @@
 </fmt:message></h2>
 
 <c:if test="${not empty error}">
-    <div class="alert alert-error">${error}</div>
+    <div class="alert alert-error">${fn:escapeXml(error)}</div>
 </c:if>
 
 <div class="alert"><fmt:message key="label.userGroupProvider.delete.confirm"/></div>

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/editProviderForm.jsp
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/editProviderForm.jsp
@@ -24,15 +24,21 @@
 </fmt:message></h2>
 
 <c:if test="${not empty error}">
-    <div class="alert alert-error">${error}</div>
+    <div class="alert alert-error">${fn:escapeXml(error)}</div>
 </c:if>
 
 <form style="margin: 0;" action="${flowExecutionUrl}" method="post" onsubmit="workInProgress('${i18nWaiting}')">
     <input type="hidden" name="providerKey" value="${providerKey}"/>
     <input type="hidden" name="providerClass" value="${providerClass}"/>
-    <input type="hidden" name="editJSP" value="${editJSP}"/>
 
-    <jsp:include page="${editJSP}"/>
+    <c:choose>
+        <c:when test="${not empty editJSP}">
+            <jsp:include page="${editJSP}"/>
+        </c:when>
+        <c:otherwise>
+            <div class="alert alert-error"><fmt:message key="label.userGroupProvider.unknownProvider"/></div>
+        </c:otherwise>
+    </c:choose>
 
     <div>
         <button class="btn btn-primary" type="submit" name="_eventId_save">

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/flow.xml
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/flow.xml
@@ -32,7 +32,7 @@
         <on-entry>
             <evaluate expression="requestParameters.providerName" result="flashScope.providerName"/>
             <evaluate expression="requestParameters.providerClass" result="flashScope.providerClass"/>
-            <evaluate expression="requestParameters.createJSP" result="flashScope.createJSP"/>
+            <evaluate expression="userGroupProviderHandler.resolveCreateJSP(requestParameters.providerClass)" result="flashScope.createJSP"/>
         </on-entry>
         <transition on="create" to="createProvider"/>
         <transition on="cancel" to="theEnd"/>
@@ -50,7 +50,7 @@
         <on-entry>
             <evaluate expression="requestParameters.providerKey" result="flashScope.providerKey"/>
             <evaluate expression="requestParameters.providerClass" result="flashScope.providerClass"/>
-            <evaluate expression="requestParameters.editJSP" result="flashScope.editJSP"/>
+            <evaluate expression="userGroupProviderHandler.resolveEditJSP(requestParameters.providerClass)" result="flashScope.editJSP"/>
         </on-entry>
         <transition on="save" to="editProvider"/>
         <transition on="cancel" to="theEnd"/>

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/view.jsp
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.flow/view.jsp
@@ -112,9 +112,6 @@
                     <c:if test="${userGroupProvider.editSupported or userGroupProvider.deleteSupported}">
                         <input type="hidden" name="providerClass" value="${userGroupProvider.providerClass}"/>
                     </c:if>
-                    <c:if test="${userGroupProvider.editSupported}">
-                        <input type="hidden" name="editJSP" value="${userGroupProvider.editJSP}"/>
-                    </c:if>
 
                     <c:choose>
                         <c:when test="${userGroupProvider.running}">
@@ -152,7 +149,6 @@
         <form style="margin: 0;" action="${flowExecutionUrl}" method="post">
             <input type="hidden" name="providerClass" value="${createConfiguration.key}"/>
             <input type="hidden" name="providerName" value="${createConfiguration.value.name}"/>
-            <input type="hidden" name="createJSP" value="${createConfiguration.value.createJSP}"/>
 
             <button class="btn" type="submit" name="_eventId_createProvider">
                 <i class="icon icon-plus"></i>&nbsp;<fmt:message key="label.userGroupProvider.create">

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/createProviderForm.jsp
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/createProviderForm.jsp
@@ -28,16 +28,22 @@
 </div>
 
 <c:if test="${not empty error}">
-    <div class="alert alert-danger">${error}</div>
+    <div class="alert alert-danger">${fn:escapeXml(error)}</div>
 </c:if>
 
 <div class="panel panel-default">
     <div class="panel-body">
         <form style="margin: 0;" action="${flowExecutionUrl}" method="post" onsubmit="workInProgress('${i18nWaiting}')">
             <input type="hidden" name="providerClass" value="${providerClass}"/>
-            <input type="hidden" name="createJSP" value="${createJSP}"/>
 
-            <jsp:include page="${createJSP}"/>
+            <c:choose>
+                <c:when test="${not empty createJSP}">
+                    <jsp:include page="${createJSP}"/>
+                </c:when>
+                <c:otherwise>
+                    <div class="alert alert-danger"><fmt:message key="label.userGroupProvider.unknownProvider"/></div>
+                </c:otherwise>
+            </c:choose>
 
             <div class="form-group form-group-sm">
                 <button class="btn btn-primary btn-raised pull-right" type="submit" name="_eventId_create">

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/deleteProviderForm.jsp
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/deleteProviderForm.jsp
@@ -27,7 +27,7 @@
 </div>
 
 <c:if test="${not empty error}">
-    <div class="alert alert-danger">${error}</div>
+    <div class="alert alert-danger">${fn:escapeXml(error)}</div>
 </c:if>
 
 <div class="panel panel-default">

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/editProviderForm.jsp
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/editProviderForm.jsp
@@ -27,7 +27,7 @@
 </div>
 
 <c:if test="${not empty error}">
-    <div class="alert alert-danger">${error}</div>
+    <div class="alert alert-danger">${fn:escapeXml(error)}</div>
 </c:if>
 
 <div class="panel panel-default">
@@ -35,9 +35,15 @@
         <form style="margin: 0;" action="${flowExecutionUrl}" method="post" onsubmit="workInProgress('${i18nWaiting}')">
             <input type="hidden" name="providerKey" value="${providerKey}"/>
             <input type="hidden" name="providerClass" value="${providerClass}"/>
-            <input type="hidden" name="editJSP" value="${editJSP}"/>
 
-            <jsp:include page="${editJSP}"/>
+            <c:choose>
+                <c:when test="${not empty editJSP}">
+                    <jsp:include page="${editJSP}"/>
+                </c:when>
+                <c:otherwise>
+                    <div class="alert alert-danger"><fmt:message key="label.userGroupProvider.unknownProvider"/></div>
+                </c:otherwise>
+            </c:choose>
 
             <div class="form-group form-group-sm">
                 <button class="btn btn-primary btn-raised pull-right" type="submit" name="_eventId_save">

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/flow.xml
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/flow.xml
@@ -32,7 +32,7 @@
         <on-entry>
             <evaluate expression="requestParameters.providerName" result="flashScope.providerName"/>
             <evaluate expression="requestParameters.providerClass" result="flashScope.providerClass"/>
-            <evaluate expression="requestParameters.createJSP" result="flashScope.createJSP"/>
+            <evaluate expression="userGroupProviderHandler.resolveCreateJSP(requestParameters.providerClass)" result="flashScope.createJSP"/>
         </on-entry>
         <transition on="create" to="createProvider"/>
         <transition on="cancel" to="theEnd"/>
@@ -50,7 +50,7 @@
         <on-entry>
             <evaluate expression="requestParameters.providerKey" result="flashScope.providerKey"/>
             <evaluate expression="requestParameters.providerClass" result="flashScope.providerClass"/>
-            <evaluate expression="requestParameters.editJSP" result="flashScope.editJSP"/>
+            <evaluate expression="userGroupProviderHandler.resolveEditJSP(requestParameters.providerClass)" result="flashScope.editJSP"/>
         </on-entry>
         <transition on="save" to="editProvider"/>
         <transition on="cancel" to="theEnd"/>

--- a/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/view.jsp
+++ b/core/src/main/resources/jnt_serverSettingsUserGroupProviders/html/serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/view.jsp
@@ -119,9 +119,6 @@
                             <c:if test="${userGroupProvider.editSupported or userGroupProvider.deleteSupported}">
                                 <input type="hidden" name="providerClass" value="${userGroupProvider.providerClass}"/>
                             </c:if>
-                            <c:if test="${userGroupProvider.editSupported}">
-                                <input type="hidden" name="editJSP" value="${userGroupProvider.editJSP}"/>
-                            </c:if>
 
                             <c:choose>
                                 <c:when test="${userGroupProvider.running}">
@@ -173,7 +170,6 @@
                 <form style="margin: 0;" action="${flowExecutionUrl}" method="post">
                     <input type="hidden" name="providerClass" value="${createConfiguration.key}"/>
                     <input type="hidden" name="providerName" value="${createConfiguration.value.name}"/>
-                    <input type="hidden" name="createJSP" value="${createConfiguration.value.createJSP}"/>
 
                     <button class="btn btn-raised btn-primary pull-right" type="submit" name="_eventId_createProvider">
                         <fmt:message key="label.userGroupProvider.create">

--- a/core/src/main/resources/resources/external-provider-users-groups_de.properties
+++ b/core/src/main/resources/resources/external-provider-users-groups_de.properties
@@ -14,3 +14,4 @@ label.userGroupProvider.stopped=Gestoppt
 label.userGroupProvider.supportsGroups=Unterstützt Gruppen
 label.userGroupProvider.suspend=Anhalten
 serverSettings.manageUserGroupProviders=Benutzer und Gruppen Anbieter
+label.userGroupProvider.unknownProvider=Dieser Anbietertyp ist auf diesem Server nicht registriert.

--- a/core/src/main/resources/resources/external-provider-users-groups_en.properties
+++ b/core/src/main/resources/resources/external-provider-users-groups_en.properties
@@ -16,4 +16,5 @@ label.userGroupProvider.stopped=Stopped
 label.userGroupProvider.supportsGroups=Supports groups
 label.userGroupProvider.suspend=Suspend
 label.userGroupProvider.targetUnavailable=Site unavailable
+label.userGroupProvider.unknownProvider=This provider type is not registered on this server.
 serverSettings.manageUserGroupProviders=User and group providers

--- a/core/src/main/resources/resources/external-provider-users-groups_fr.properties
+++ b/core/src/main/resources/resources/external-provider-users-groups_fr.properties
@@ -17,3 +17,4 @@ label.userGroupProvider.supportsGroups=Supporte les groupes
 label.userGroupProvider.suspend=Suspendre
 label.userGroupProvider.targetUnavailable=Site non disponible
 serverSettings.manageUserGroupProviders=Providers d'utilisateurs et de groupes
+label.userGroupProvider.unknownProvider=Ce type de provider n'est pas enregistre sur ce serveur.

--- a/core/src/test/java/org/jahia/modules/external/users/admin/UserGroupProviderAdminFlowTest.java
+++ b/core/src/test/java/org/jahia/modules/external/users/admin/UserGroupProviderAdminFlowTest.java
@@ -1,0 +1,104 @@
+package org.jahia.modules.external.users.admin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jahia.modules.external.users.ExternalUserGroupService;
+import org.jahia.modules.external.users.UserGroupProviderConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Tests that the JSP included by the create and edit forms is resolved from the provider registry and can never be
+ * chosen by the caller.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UserGroupProviderAdminFlowTest {
+
+    private static final String LDAP_CLASS = "org.jahia.services.usermanager.ldap.LDAPUserGroupProvider";
+
+    private static final String LDAP_CREATE_JSP = "/modules/ldap/userGroupProviderCreate.jsp";
+
+    private static final String LDAP_EDIT_JSP = "/modules/ldap/userGroupProviderEdit.jsp";
+
+    /** The path SEC-289 proved could be included when the flow trusted the request parameter. */
+    private static final String ATTACKER_JSP = "/modules/tools/jcrConsole.jsp";
+
+    private final Map<String, UserGroupProviderConfiguration> configurations = new HashMap<>();
+
+    @Mock
+    private ExternalUserGroupService externalUserGroupService;
+
+    @Mock
+    private UserGroupProviderConfiguration ldapConfiguration;
+
+    @InjectMocks
+    private UserGroupProviderAdminFlow handler;
+
+    @Before
+    public void setUp() {
+        configurations.put(LDAP_CLASS, ldapConfiguration);
+        lenient().when(externalUserGroupService.getProviderConfigurations()).thenReturn(configurations);
+    }
+
+    @Test
+    public void shouldResolveCreateJSPFromTheRegistry() {
+        when(ldapConfiguration.isCreateSupported()).thenReturn(true);
+        when(ldapConfiguration.getCreateJSP()).thenReturn(LDAP_CREATE_JSP);
+
+        assertEquals(LDAP_CREATE_JSP, handler.resolveCreateJSP(LDAP_CLASS));
+    }
+
+    @Test
+    public void shouldResolveEditJSPFromTheRegistry() {
+        when(ldapConfiguration.isEditSupported()).thenReturn(true);
+        when(ldapConfiguration.getEditJSP()).thenReturn(LDAP_EDIT_JSP);
+
+        assertEquals(LDAP_EDIT_JSP, handler.resolveEditJSP(LDAP_CLASS));
+    }
+
+    @Test
+    public void shouldNotResolveAJSPPathSuppliedByTheCaller() {
+        // SEC-289: the caller used to pass the JSP path itself. It is now only ever a registry key, and a path is not
+        // a registered provider class, so nothing is included.
+        assertNull(handler.resolveCreateJSP(ATTACKER_JSP));
+        assertNull(handler.resolveEditJSP(ATTACKER_JSP));
+        assertNull(handler.resolveCreateJSP("/WEB-INF/web.xml"));
+        assertNull(handler.resolveEditJSP("/WEB-INF/web.xml"));
+    }
+
+    @Test
+    public void shouldNotResolveAnUnregisteredProviderClass() {
+        assertNull(handler.resolveCreateJSP("com.example.NotRegistered"));
+        assertNull(handler.resolveEditJSP("com.example.NotRegistered"));
+    }
+
+    @Test
+    public void shouldNotResolveANullProviderClass() {
+        assertNull(handler.resolveCreateJSP(null));
+        assertNull(handler.resolveEditJSP(null));
+    }
+
+    @Test
+    public void shouldNotResolveCreateJSPWhenCreationIsNotSupported() {
+        when(ldapConfiguration.isCreateSupported()).thenReturn(false);
+
+        assertNull(handler.resolveCreateJSP(LDAP_CLASS));
+    }
+
+    @Test
+    public void shouldNotResolveEditJSPWhenEditionIsNotSupported() {
+        when(ldapConfiguration.isEditSupported()).thenReturn(false);
+
+        assertNull(handler.resolveEditJSP(LDAP_CLASS));
+    }
+}

--- a/core/src/test/java/org/jahia/modules/external/users/admin/UserGroupProviderFlowDefinitionTest.java
+++ b/core/src/test/java/org/jahia/modules/external/users/admin/UserGroupProviderFlowDefinitionTest.java
@@ -1,0 +1,109 @@
+package org.jahia.modules.external.users.admin;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+/**
+ * Guards the shape of the user/group providers webflow: the JSP the create and edit forms include must be resolved
+ * from the provider registry, never carried in the request.
+ * <p>
+ * The sink these tests protect lives in the flow definition and the JSPs rather than in Java, so it is asserted on the
+ * resources themselves. Both skins carry the same forms and both are checked.
+ */
+public class UserGroupProviderFlowDefinitionTest {
+
+    private static final String BASE = "/jnt_serverSettingsUserGroupProviders/html/";
+
+    private static final String[] FLOWS = {
+            BASE + "serverSettingsUserGroupProviders.flow/",
+            BASE + "serverSettingsUserGroupProviders.settingsBootstrap3GoogleMaterialStyle.flow/"
+    };
+
+    @Test
+    public void flowShouldNotBindTheIncludedJSPFromTheRequest() throws IOException {
+        for (String flow : FLOWS) {
+            String definition = read(flow + "flow.xml");
+            assertFalse(flow + "flow.xml must not read the included JSP from the request",
+                    definition.contains("requestParameters.createJSP"));
+            assertFalse(flow + "flow.xml must not read the included JSP from the request",
+                    definition.contains("requestParameters.editJSP"));
+        }
+    }
+
+    @Test
+    public void flowShouldResolveTheIncludedJSPFromTheRegistry() throws IOException {
+        for (String flow : FLOWS) {
+            String definition = read(flow + "flow.xml");
+            assertTrue(flow + "flow.xml must resolve the create JSP from the provider class",
+                    definition.contains("userGroupProviderHandler.resolveCreateJSP(requestParameters.providerClass)"));
+            assertTrue(flow + "flow.xml must resolve the edit JSP from the provider class",
+                    definition.contains("userGroupProviderHandler.resolveEditJSP(requestParameters.providerClass)"));
+        }
+    }
+
+    @Test
+    public void formsShouldNotRoundTripTheIncludedJSPThroughTheBrowser() throws IOException {
+        for (String flow : FLOWS) {
+            for (String page : new String[] { "view.jsp", "createProviderForm.jsp", "editProviderForm.jsp" }) {
+                String markup = read(flow + page);
+                assertFalse(flow + page + " must not submit the included JSP as a request parameter",
+                        markup.contains("name=\"createJSP\""));
+                assertFalse(flow + page + " must not submit the included JSP as a request parameter",
+                        markup.contains("name=\"editJSP\""));
+            }
+        }
+    }
+
+    @Test
+    public void formsShouldIncludeTheResolvedJSPOnlyWhenOneWasResolved() throws IOException {
+        for (String flow : FLOWS) {
+            String create = read(flow + "createProviderForm.jsp");
+            assertTrue(flow + "createProviderForm.jsp must include the resolved JSP",
+                    create.contains("<jsp:include page=\"${createJSP}\"/>"));
+            assertTrue(flow + "createProviderForm.jsp must not include anything when no JSP was resolved",
+                    create.contains("${not empty createJSP}"));
+
+            String edit = read(flow + "editProviderForm.jsp");
+            assertTrue(flow + "editProviderForm.jsp must include the resolved JSP",
+                    edit.contains("<jsp:include page=\"${editJSP}\"/>"));
+            assertTrue(flow + "editProviderForm.jsp must not include anything when no JSP was resolved",
+                    edit.contains("${not empty editJSP}"));
+        }
+    }
+
+    @Test
+    public void formsShouldEscapeTheErrorTheyReportBack() throws IOException {
+        // flow.xml puts the raw rootCauseException in flash scope, so whatever the caller managed to get into the
+        // message must not reach the page as markup.
+        for (String flow : FLOWS) {
+            for (String page : new String[] { "createProviderForm.jsp", "editProviderForm.jsp", "deleteProviderForm.jsp" }) {
+                String markup = read(flow + page);
+                assertFalse(flow + page + " must not write the error out unescaped",
+                        markup.contains(">${error}<"));
+                assertTrue(flow + page + " must escape the error it reports back",
+                        markup.contains("${fn:escapeXml(error)}"));
+            }
+        }
+    }
+
+    private static String read(String resource) throws IOException {
+        try (InputStream in = UserGroupProviderFlowDefinitionTest.class.getResourceAsStream(resource)) {
+            assertNotNull("Missing resource " + resource, in);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+            return new String(out.toByteArray(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Resolve the user/group provider create and edit forms' included JSP from the provider registry instead of the request.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
